### PR TITLE
MAJOR - Add features to support full OpenSearch schema management

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,11 @@ name: Run tests
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    branches:
+      - "*"
   push:
     branches:
-      - "main"
+      - "*"
 
 jobs:
   e2e-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,6 @@
 name: Run tests
 
-on:
-  pull_request:
-    branches:
-      - "*"
-  push:
-    branches:
-      - "*"
+on: [push, pull_request]
 
 jobs:
   e2e-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Run tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - "*"
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,10 @@ name: Run tests
 
 on:
   pull_request:
-    branches:
-      - "*"
+    types: [opened, reopened, edited]
   push:
     branches:
-      - "*"
+      - "main"
 
 jobs:
   e2e-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
 name: Run tests
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "*"
   push:
     branches:
-      - "main"
+      - "*"
 
 jobs:
   e2e-test:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This will use your `source_client` to create a new index named 'reindexer_versio
 When reindexing from one cluster to another, migrations should be run first (step 8) before initializing the destination cluster with:
 `reindexer init-index`
 
-### 5. Create revision
+### 5. Create revision (repeat if you have multiple indices)
 Two revision types are supported, `painless` which uses the native OpenSearch Reindex API, and `python` which using
 the OpenSearch Scroll API and Bulk inserts. `painless` revisions are recommended as they are more performant than 
 `python` revisions. You don't have to use one or the other; `./migrations/versions/` can contain a combination of 
@@ -66,7 +66,10 @@ You can modify them if you find yourself making the same changes to revision fil
 Navigate to your revision file `./migrations/versions/1_my_revision_name.py`
 
 #### Painless
+
 Modify `source` and `destination` in `REINDEX_BODY`, you can optionally set `DESTINATION_MAPPINGS`.
+
+Note: If you only want to create the index, set the source index to `None` e.g. `"source": {"index": "reindexer_revision_1"},`
 
 To transform data as data is reindexed, you can use 
 painless scripts. For example, the following will convert data in field "c" from an object to a JSON string 
@@ -100,6 +103,8 @@ For more information on `REINDEX_BODY` see https://opensearch.org/docs/latest/op
 #### Python
 Modify `SOURCE_INDEX` and `DESTINATION_INDEX`, you can optionally set `DESTINATION_MAPPINGS`.
 
+Note: If you only want to create the index, set the source index to `None` e.g. `"source": {"index": "reindexer_revision_1"},`
+
 To modify documents as they are being re-indexed to the destination index, update `def transform_document`. For example:
 ```python
 class Migration(BaseMigration):
@@ -117,3 +122,27 @@ class Migration(BaseMigration):
 
 Note: When `reindexer run` is executed, it will compare revision versions in `./migrations/versions/...` to the version number in `reindexer_version` index of the source cluster.
 All revisions that have not been run will be run one after another. 
+
+
+## FAQ 💬 🙋 
+#### How do I start using `OpenSearch reindexer` in a new project?
+To get started with `OpenSearch reindexer` in a new project, simply follow the getting started guide above.
+
+#### What happens if multiple revisions need to be executed?
+`OpenSearch reindexer` compares the remote version in the `reindexer_version` index on your OpenSearch cluster to your local version. 
+Any versions local revisions that have not been executed will be executed one after another.
+
+#### What if I have multiple indices?
+Create a revision for each index and follow the same steps as you would for one index.
+
+#### How do I migrate from another schema management tool to `OpenSearch reindexer`?
+In this answer, we assume that you already have 1 or many indices.
+
+Complete steps 1 - 6 of the getting started guide, repeating steps 5 and 6 for each index. During step 6, set your source index to `None`.
+This will tell `OpenSearch reindexer` to just create the index.
+
+#### What happens when someone downloads my project that uses `OpenSearch reindexer` for the first time and revisions already exist?
+If the project points to an OpenSearch cluster that has an up-to-date `reindexer_version` index, then nothing will happen the next time `reindexer run` is executed.
+
+If the person downloading the project points to a different OpenSearch cluster that hasn't been initialized yet, they should run `reindexer init-index` to create and initialize
+`reindexer_version` index followed by `reindexer run`. This will then run all migrations one after the other.

--- a/README.md
+++ b/README.md
@@ -126,23 +126,26 @@ All revisions that have not been run will be run one after another.
 
 ## FAQ 💬 🙋 
 #### How do I start using `OpenSearch reindexer` in a new project?
-To get started with `OpenSearch reindexer` in a new project, simply follow the getting started guide above.
+To start using `OpenSearch reindexer`, simply follow the steps outlined in the getting started guide.
 
 #### What happens if multiple revisions need to be executed?
 `OpenSearch reindexer` compares the remote version in the `reindexer_version` index on your OpenSearch cluster to your local version. 
-Any versions local revisions that have not been executed will be executed one after another.
+Any versions that have not been executed will be executed one after another.
 
-#### What if I have multiple indices?
-Create a revision for each index and follow the same steps as you would for one index.
+#### How to handle multiple indices?
+Create a revision for each index and follow the same steps as you would for a single index.
 
 #### How do I migrate from another schema management tool to `OpenSearch reindexer`?
-In this answer, we assume that you already have 1 or many indices.
+To migrate to `OpenSearch reindexer`, follow steps 1-6 in the getting started guide, repeating steps 5 and 6 for each 
+index. Set the source index to None during step 6 to create the destination index if it doesn't exist, or if it already 
+exists, proceed to the next revision.
 
-Complete steps 1 - 6 of the getting started guide, repeating steps 5 and 6 for each index. During step 6, set your source index to `None`.
-This will tell `OpenSearch reindexer` to just create the index.
+#### Downloading a project that uses `OpenSearch reindexer`
+If the `reindexer_version` index on the OpenSearch cluster is up-to-date, running `reindexer run` won't do anything.
+However, if the OpenSearch cluster hasn't been initialized, run `reindexer init-index` followed by `reindexer run` to 
+create and initialize the `reindexer_version` index and run all migrations.
 
-#### What happens when someone downloads my project that uses `OpenSearch reindexer` for the first time and revisions already exist?
-If the project points to an OpenSearch cluster that has an up-to-date `reindexer_version` index, then nothing will happen the next time `reindexer run` is executed.
+#### Reindexing data from one OpenSearch cluster to another
+Follow the same steps for reindexing data to the same cluster, but update the "destination_client" in `./migrations/env.py`.
 
-If the person downloading the project points to a different OpenSearch cluster that hasn't been initialized yet, they should run `reindexer init-index` to create and initialize
-`reindexer_version` index followed by `reindexer run`. This will then run all migrations one after the other.
+Once you have reindexed all indices from one cluster to another, update the source and destination clients.

--- a/opensearch_reindexer/__init__.py
+++ b/opensearch_reindexer/__init__.py
@@ -120,8 +120,8 @@ def init_index():
 
     if source_client.indices.exists(index=version_control_index):
         source_client.search(index=version_control_index)
-        print(f'Index "{version_control_index}" already exists')
-        exit(1)
+        print(f'Index "{version_control_index}" already initialized.')
+        exit(0)
 
     source_client.indices.create(
         index=version_control_index,

--- a/opensearch_reindexer/__init__.py
+++ b/opensearch_reindexer/__init__.py
@@ -52,10 +52,6 @@ config = Config(
     language=Language.python,
 )
 
-
-def reindex():
-    Migration(config).reindex()
-
     """
     )
     Path("./migrations/migration_template_painless.py").write_text(
@@ -68,15 +64,19 @@ REINDEX_BODY = {
 DESTINATION_INDEX_BODY = None
 
 
+class Migration(BaseMigration):
+    def before_revision(self):
+        pass
+
+    def after_revision(self):
+        pass
+
+
 config = Config(
     reindex_body=REINDEX_BODY,
     destination_index_body=DESTINATION_INDEX_BODY,
     language=Language.painless,
 )
-
-
-def reindex():
-    BaseMigration(config).reindex()
 
         """
     )

--- a/opensearch_reindexer/__init__.py
+++ b/opensearch_reindexer/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import typer
 from rich import print
 
-from opensearch_reindexer.base import BaseMigration, Language, Config
+from opensearch_reindexer.base import BaseMigration, Language
 
 app = typer.Typer()
 
@@ -184,6 +184,15 @@ def run():
     Runs 0 or many migrations returned by `BaseMigration().get_revisions_to_execute()
     """
     verify_reindexer_init_execution()
+    from opensearch_reindexer.db import dynamically_import_migrations
+
+    source_client, _, version_control_index = dynamically_import_migrations()
+
+    if not source_client.indices.exists(index=version_control_index):
+        print(
+            f'Version control index "{version_control_index}" does not exist.\nCreate it by running "reindexer init-index"'
+        )
+        exit(1)
     BaseMigration().handle_migration()
 
 

--- a/opensearch_reindexer/__init__.py
+++ b/opensearch_reindexer/__init__.py
@@ -1,11 +1,10 @@
 import os
 from pathlib import Path
-from typing import Literal, Union
 
 import typer
 from rich import print
 
-from opensearch_reindexer.base import BaseMigration, Language
+from opensearch_reindexer.base import BaseMigration, Language, Config
 
 app = typer.Typer()
 
@@ -92,6 +91,7 @@ OPENSEARCH_PASSWORD = "admin"
 OPENSEARCH_USE_SSL = True
 OPENSEARCH_VERIFY_CERTS = False
 
+VERSION_CONTROL_INDEX = "reindexer_version"
 
 # Create the client with SSL/TLS enabled, but hostname verification disabled.
 source_client = OpenSearch(
@@ -113,42 +113,27 @@ def init_index():
     """
     Initializes the 'reindexer_version' index in the 'source_client' with the highest local revision version number.
     """
-    # First check if `reindexer init` has been run.
-    if not os.path.exists("migrations/versions"):
-        print(
-            'No migrations/versions directory found.\n\nInitialize your project first:\n1. "reindexer init"'
-        )
-        raise typer.Exit(1)
-
+    verify_reindexer_init_execution()
     from opensearch_reindexer.db import dynamically_import_migrations
 
-    source_client, _ = dynamically_import_migrations()
-    version_index = "reindexer_version"
+    source_client, _, version_control_index = dynamically_import_migrations()
 
-    if source_client.indices.exists(index=version_index):
-        source_client.search(index=version_index)
-        print(f'[bold red]Index "{version_index}" already exists[/bold red]')
-        raise typer.Exit(1)
+    if source_client.indices.exists(index=version_control_index):
+        source_client.search(index=version_control_index)
+        print(f'Index "{version_control_index}" already exists')
+        exit(1)
 
     source_client.indices.create(
-        index=version_index,
+        index=version_control_index,
     )
-    highest_version = BaseMigration().get_local_migration_version()
 
-    if highest_version != 0:
-        print(
-            "Local revisions were detected. If the destination index from your most recent revision "
-            "does not exist, this tells us you are initiating a project for the first time — we will create the"
-            "destination index during 'reindexer run'. If the destination index already exists, this tells us you "
-            "have migrated to a new OpenSearch cluster. In this case, nothing will happen when you run 'reindexer run'."
-        )
-
-    print(f'"versionNum" was initialized to {highest_version}')
+    version: int = 0
     source_client.index(
-        index=version_index,
-        body={"versionNum": highest_version},
+        index=version_control_index,
+        body={"versionNum": version},
         refresh="wait_for",
     )
+    print(f'"versionNum" was initialized to {version}')
 
 
 @app.command()
@@ -166,12 +151,12 @@ def revision(
     """
     try:
         lang = Language[language]
+        message = message.replace(" ", "_")
+        BaseMigration.valid_file_name(f"{message}.py")
+        BaseMigration().create_revision(message, lang)
     except KeyError:
-        print(f'Expected a language of "painless" or "python" but got {language}')
-        raise typer.Exit(1)
-    message = message.replace(" ", "_")
-    BaseMigration.valid_file_name(message)
-    BaseMigration().create_revision(message, lang)
+        print(f'Expected a language of "painless" or "python" but got "{language}"')
+        exit(1)
 
 
 @app.command()
@@ -179,14 +164,15 @@ def list():
     """
     Returns ordered list of revisions that have not been executed.
     """
+    verify_reindexer_init_execution()
     from opensearch_reindexer.db import dynamically_import_migrations
 
-    source_client, _ = dynamically_import_migrations()
+    source_client, _, _ = dynamically_import_migrations()
     revisions = BaseMigration().get_revisions_to_execute()
 
     if len(revisions) == 0:
         print("You are up to date. No revisions need to be executed.")
-        raise typer.Exit()
+        exit(0)
 
     for rev in revisions:
         print(rev)
@@ -197,4 +183,13 @@ def run():
     """
     Runs 0 or many migrations returned by `BaseMigration().get_revisions_to_execute()
     """
+    verify_reindexer_init_execution()
     BaseMigration().handle_migration()
+
+
+def verify_reindexer_init_execution():
+    if not os.path.exists("migrations/versions"):
+        print(
+            'No migrations/versions directory found.\n\nInitialize your project first:\n1. "reindexer init"'
+        )
+        exit(1)

--- a/opensearch_reindexer/__init__.py
+++ b/opensearch_reindexer/__init__.py
@@ -184,15 +184,6 @@ def run():
     Runs 0 or many migrations returned by `BaseMigration().get_revisions_to_execute()
     """
     verify_reindexer_init_execution()
-    from opensearch_reindexer.db import dynamically_import_migrations
-
-    source_client, _, version_control_index = dynamically_import_migrations()
-
-    if not source_client.indices.exists(index=version_control_index):
-        print(
-            f'Version control index "{version_control_index}" does not exist.\nCreate it by running "reindexer init-index"'
-        )
-        exit(1)
     BaseMigration().handle_migration()
 
 

--- a/opensearch_reindexer/__init__.py
+++ b/opensearch_reindexer/__init__.py
@@ -52,7 +52,11 @@ config = Config(
     destination_index_body=DESTINATION_INDEX_BODY,
     language=Language.python,
 )
-Migration(config).reindex()
+
+
+def reindex():
+    Migration(config).reindex()
+
     """
     )
     Path("./migrations/migration_template_painless.py").write_text(
@@ -70,7 +74,11 @@ config = Config(
     destination_index_body=DESTINATION_INDEX_BODY,
     language=Language.painless,
 )
-BaseMigration(config).reindex()
+
+
+def reindex():
+    BaseMigration(config).reindex()
+
         """
     )
     Path("./migrations/env.py").write_text(
@@ -129,7 +137,10 @@ def init_index():
 
     if highest_version != 0:
         print(
-            "Local revisions were detected. We assume you have migrated from one OpenSearch Cluster to another."
+            "Local revisions were detected. If the destination index from your most recent revision "
+            "does not exist, this tells us you are initiating a project for the first time — we will create the"
+            "destination index during 'reindexer run'. If the destination index already exists, this tells us you "
+            "have migrated to a new OpenSearch cluster. In this case, nothing will happen when you run 'reindexer run'."
         )
 
     print(f'"versionNum" was initialized to {highest_version}')
@@ -172,6 +183,11 @@ def list():
 
     source_client, _ = dynamically_import_migrations()
     revisions = BaseMigration().get_revisions_to_execute()
+
+    if len(revisions) == 0:
+        print("You are up to date. No revisions need to be executed.")
+        raise typer.Exit()
+
     for rev in revisions:
         print(rev)
 

--- a/opensearch_reindexer/base.py
+++ b/opensearch_reindexer/base.py
@@ -135,7 +135,7 @@ class BaseMigration:
 
             if not revisions_to_execute:
                 print("No new revisions found.")
-                exit(1)
+                exit(0)
 
             return revisions_to_execute
         except FileNotFoundError:

--- a/opensearch_reindexer/base.py
+++ b/opensearch_reindexer/base.py
@@ -3,7 +3,7 @@ import re
 import shutil
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, List
+from typing import List, Optional
 
 import opensearchpy.exceptions
 from opensearchpy import OpenSearch
@@ -35,7 +35,11 @@ class BaseMigration:
 
         from opensearch_reindexer.db import dynamically_import_migrations
 
-        source_client, destination_client, version_control_index = dynamically_import_migrations()
+        (
+            source_client,
+            destination_client,
+            version_control_index,
+        ) = dynamically_import_migrations()
 
         self.source_client: OpenSearch = source_client
         self.destination_client: OpenSearch = destination_client
@@ -106,17 +110,19 @@ class BaseMigration:
             revision_files = self.get_revisions()
             if not revision_files:
                 print(
-                    'No revision files found in "./migrations/versions".\nPlease create one by running: "reindexer revision"')
+                    'No revision files found in "./migrations/versions".\nPlease create one by running: "reindexer revision"'
+                )
                 exit(1)
 
             remote_version_num = self.get_remote_version_num()
             revisions_to_execute = [
-                file for file in revision_files
+                file
+                for file in revision_files
                 if int(re.search(r"\d+", file).group()) > remote_version_num
             ]
 
             if not revisions_to_execute:
-                print('No new revisions found.')
+                print("No new revisions found.")
                 exit(1)
 
             return revisions_to_execute

--- a/opensearch_reindexer/db.py
+++ b/opensearch_reindexer/db.py
@@ -6,7 +6,7 @@ from opensearchpy import OpenSearch
 
 
 def dynamically_import_migrations() -> Union[
-    tuple[OpenSearch, OpenSearch], tuple[None, None]
+    tuple[OpenSearch, OpenSearch, str], tuple[None, None]
 ]:
     """
     Dynamically imports the necessary migration files and returns the 'source_client' from the 'env.py' file.
@@ -22,7 +22,7 @@ def dynamically_import_migrations() -> Union[
         # Load the module
         env = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(env)
-        return env.source_client, env.destination_client
+        return env.source_client, env.destination_client, env.VERSION_CONTROL_INDEX
     except FileNotFoundError:
         pass
     return None, None

--- a/opensearch_reindexer/db.py
+++ b/opensearch_reindexer/db.py
@@ -14,14 +14,21 @@ def dynamically_import_migrations() -> Union[
     try:
         # Obtain the file's path
         current_working_dir = os.getcwd()
-        file_path = os.path.join(current_working_dir, "migrations", "env.py")
+        migrations_dir = os.path.join(current_working_dir, "migrations")
+        init_file_path = os.path.join(migrations_dir, "__init__.py")
+        file_path = os.path.join(migrations_dir, "env.py")
 
         # Create a ModuleSpec object
+        init_spec = importlib.util.spec_from_file_location("init", init_file_path)
         spec = importlib.util.spec_from_file_location("env", file_path)
 
         # Load the module
+        init = importlib.util.module_from_spec(init_spec)
         env = importlib.util.module_from_spec(spec)
+
+        init_spec.loader.exec_module(init)
         spec.loader.exec_module(env)
+
         return env.source_client, env.destination_client, env.VERSION_CONTROL_INDEX
     except FileNotFoundError:
         pass

--- a/opensearch_reindexer/helper.py
+++ b/opensearch_reindexer/helper.py
@@ -1,0 +1,40 @@
+import json
+
+from opensearchpy import OpenSearch
+
+
+def create_or_update_alias(client: OpenSearch, alias: str, index_name: str) -> None:
+    """Create or update an alias in an OpenSearch index. If the alias already exists, remove any
+    existing indices associated with the alias and update it to point to the specified index.
+
+    Arguments:
+        client (OpenSearch): An instance of the `OpenSearch` class representing a connection to an OpenSearch service.
+        alias (str): The name of the alias to be created or updated.
+        index_name (str): The name of the index to which the alias should point.
+
+    Returns:
+        None
+    """
+    if not client.indices.exists_alias(name=alias):
+        client.indices.put_alias(name=alias, index=index_name)
+    else:
+        client.indices.update_aliases(body={"actions": [
+            {"remove": {"index": i, "alias": alias} for i in client.indices.get_alias(name=alias)},
+            {"add": {"index": index_name, "alias": alias}}
+        ]})
+
+
+def increment_index(index_name) -> str:
+    """Increment the suffix of an index name.
+
+    Arguments:
+        index_name (str): The index name to be incremented.
+
+    Returns:
+        str: The incremented index name.
+    """
+    try:
+        suffix = int(index_name.split("-")[-1])
+        return "-".join(index_name.split("-")[:-1]) + "-" + str(suffix + 1)
+    except ValueError:
+        return index_name + "-0"

--- a/opensearch_reindexer/helper.py
+++ b/opensearch_reindexer/helper.py
@@ -18,10 +18,17 @@ def create_or_update_alias(client: OpenSearch, alias: str, index_name: str) -> N
     if not client.indices.exists_alias(name=alias):
         client.indices.put_alias(name=alias, index=index_name)
     else:
-        client.indices.update_aliases(body={"actions": [
-            {"remove": {"index": i, "alias": alias} for i in client.indices.get_alias(name=alias)},
-            {"add": {"index": index_name, "alias": alias}}
-        ]})
+        client.indices.update_aliases(
+            body={
+                "actions": [
+                    {
+                        "remove": {"index": i, "alias": alias}
+                        for i in client.indices.get_alias(name=alias)
+                    },
+                    {"add": {"index": index_name, "alias": alias}},
+                ]
+            }
+        )
 
 
 def increment_index(index_name) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "opensearch-reindexer"
-version = "1.0.1"
+version = "2.0.0"
 description = "`opensearch-reindex` is a Python library that serves to help streamline reindexing data from one OpenSearch index to another."
 authors = ["Kenton Parton <kparton@swiple.io>"]
 readme = "README.md"

--- a/tests/e2e/test_opensearch_reindexer.py
+++ b/tests/e2e/test_opensearch_reindexer.py
@@ -119,6 +119,21 @@ class TestOpensearchReindexer:
         # assert that the correct exit code was used
         assert excinfo.value.code == 1
 
+    def test_should_show_prerequisite_steps_to_reindexer_run_two(self, clean_up):
+        import opensearch_reindexer as osr
+
+        source_client = get_os_client()
+
+        osr.init()
+        osr.init_index()
+        osr.revision("revision_1")
+        delete_index(source_client, REINDEXER_VERSION)
+        with pytest.raises(SystemExit) as excinfo:
+            osr.run()
+
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
     def test_should_not_allow_invalid_revisions_file_names(self, clean_up):
         import opensearch_reindexer as osr
 
@@ -153,7 +168,9 @@ class TestOpensearchReindexer:
         # assert that the correct exit code was used
         assert excinfo.value.code == 1
 
-    def test_should_update_reindexer_version_in_source_and_destination_cluster_when_hosts_are_different(self, clean_up, load_data):
+    def test_should_update_reindexer_version_in_source_and_destination_cluster_when_hosts_are_different(
+        self, clean_up, load_data
+    ):
         import opensearch_reindexer as osr
 
         source_client = get_os_client()
@@ -263,7 +280,6 @@ class TestOpensearchReindexer:
             client=source_client,
             index=MODIFIED_VERSION_CONTROL_INDEX_NAME,
         ) == {"versionNum": 3}
-
 
     def test_should_exit_when_source_index_does_not_exist_python(self, clean_up):
         import opensearch_reindexer as osr
@@ -741,7 +757,9 @@ def modify_destination_client_env_file():
     ssl_show_warn=False,
 )
         """
-        contents = contents.replace("destination_client = source_client", destination_client)
+        contents = contents.replace(
+            "destination_client = source_client", destination_client
+        )
 
     # Open the file in write mode and write the modified contents back to the file
     with open(f"./migrations/env.py", "w") as f:
@@ -752,8 +770,12 @@ def modify_version_control_index():
     # Open the file in read-only mode and read its contents into a string
     with open(f"./migrations/env.py", "r") as f:
         contents = f.read()
-        version_control_index = f'VERSION_CONTROL_INDEX = "{MODIFIED_VERSION_CONTROL_INDEX_NAME}"'
-        contents = contents.replace('VERSION_CONTROL_INDEX = "reindexer_version"', version_control_index)
+        version_control_index = (
+            f'VERSION_CONTROL_INDEX = "{MODIFIED_VERSION_CONTROL_INDEX_NAME}"'
+        )
+        contents = contents.replace(
+            'VERSION_CONTROL_INDEX = "reindexer_version"', version_control_index
+        )
 
     # Open the file in write mode and write the modified contents back to the file
     with open(f"./migrations/env.py", "w") as f:
@@ -761,6 +783,4 @@ def modify_version_control_index():
 
 
 def search(client: OpenSearch, index: str) -> dict:
-    return client.search(index=index, size=1, body={})["hits"]["hits"][
-        0
-    ]["_source"]
+    return client.search(index=index, size=1, body={})["hits"]["hits"][0]["_source"]

--- a/tests/e2e/test_opensearch_reindexer.py
+++ b/tests/e2e/test_opensearch_reindexer.py
@@ -14,6 +14,35 @@ REINDEXER_SOURCE_INDEX = "reindexer_source_index"
 REINDEXER_REVISION_1 = "reindexer_revision_1"
 REINDEXER_REVISION_2 = "reindexer_revision_2"
 REINDEXER_REVISION_3 = "reindexer_revision_3"
+MODIFIED_VERSION_CONTROL_INDEX_NAME = "modified_reindexer_version"
+
+REVISION_ONE_MAPPINGS = {
+    "mappings": {
+        "properties": {
+            "a": {"type": "long"},
+            "b": {"type": "long"},
+            "c": {
+                "properties": {
+                    "a": {
+                        "type": "text",
+                    },
+                    "b": {
+                        "type": "text",
+                    },
+                    "c": {"type": "long"},
+                }
+            },
+        }
+    }
+}
+REVISION_THREE_MAPPINGS = {
+    "mappings": {
+        "properties": {
+            "a": {"type": "long"},
+            "c": {"type": "text"},
+        }
+    }
+}
 
 
 @pytest.fixture()
@@ -24,6 +53,7 @@ def clean_up():
     delete_index(source_client, REINDEXER_REVISION_1)
     delete_index(source_client, REINDEXER_REVISION_2)
     delete_index(source_client, REINDEXER_REVISION_3)
+    delete_index(source_client, MODIFIED_VERSION_CONTROL_INDEX_NAME)
 
     if os.path.exists("./migrations"):
         shutil.rmtree("./migrations")
@@ -36,10 +66,94 @@ def load_data():
 
 
 class TestOpensearchReindexer:
-    def test_should_create_destination_index_and_set_to_latest_revision_version_python(self, clean_up):
-        # if revision files exist, reindexer_version index does not exist and the latest revision destination index does
-        # not exist, this tells us a project is being initialized for the first time and we want to create the
-        # destination index
+    def test_should_show_prerequisite_steps_to_reindexer_list(self, clean_up):
+        import opensearch_reindexer as osr
+
+        with pytest.raises(SystemExit) as excinfo:
+            osr.list()
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
+        osr.init()
+        with pytest.raises(SystemExit) as excinfo:
+            osr.list()
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
+        osr.init_index()
+        with pytest.raises(SystemExit) as excinfo:
+            osr.list()
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
+        osr.revision("revision_1")
+
+        osr.list()
+
+    def test_should_show_prerequisite_steps_to_reindexer_init_index(self, clean_up):
+        import opensearch_reindexer as osr
+
+        with pytest.raises(SystemExit) as excinfo:
+            osr.init_index()
+
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
+    def test_init_index_has_already_been_run(self, clean_up):
+        import opensearch_reindexer as osr
+
+        osr.init()
+        osr.init_index()
+        with pytest.raises(SystemExit) as excinfo:
+            osr.init_index()
+
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
+    def test_should_show_prerequisite_steps_to_reindexer_run(self, clean_up):
+        import opensearch_reindexer as osr
+
+        with pytest.raises(SystemExit) as excinfo:
+            osr.run()
+
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
+    def test_should_not_allow_invalid_revisions_file_names(self, clean_up):
+        import opensearch_reindexer as osr
+
+        osr.init()
+        osr.init_index()
+        with pytest.raises(SystemExit) as excinfo:
+            osr.revision("invalid.revision name")
+
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
+    def test_should_exit_if_language_is_not_supported(self, clean_up):
+        import opensearch_reindexer as osr
+
+        osr.init()
+        osr.init_index()
+        with pytest.raises(SystemExit) as excinfo:
+            osr.revision("revision_1", "unsupported_language")
+
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
+    def test_revisions_should_exist_before_running_reindexer_run(self, clean_up):
+        import opensearch_reindexer as osr
+
+        osr.init()
+        osr.init_index()
+
+        with pytest.raises(SystemExit) as excinfo:
+            osr.run()
+
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+
+    def test_should_update_reindexer_version_in_source_and_destination_cluster_when_hosts_are_different(self, clean_up, load_data):
         import opensearch_reindexer as osr
 
         source_client = get_os_client()
@@ -58,35 +172,100 @@ class TestOpensearchReindexer:
         osr.revision("revision_2", str(Language.python.value))
         osr.revision("revision_3", str(Language.python.value))
 
-        delete_index(source_client, REINDEXER_VERSION)
+        # modify revision files source/destination indices, mappings and transform_document
+        modify_revision_files_python()
+        modify_destination_client_env_file()
 
+        osr.run()
+
+        # The # docs in revision indices should match "reindexer_source_index"
+        expected_count = source_client.count(index=REINDEXER_SOURCE_INDEX)["count"]
+        assert (
+            source_client.count(index=REINDEXER_REVISION_1)["count"] == expected_count
+        )
+        assert (
+            source_client.count(index=REINDEXER_REVISION_2)["count"] == expected_count
+        )
+        assert (
+            source_client.count(index=REINDEXER_REVISION_3)["count"] == expected_count
+        )
+
+        # verify that documents were transformed as expected for each revision
+        assert search(
+            client=source_client,
+            index=REINDEXER_REVISION_1,
+        ) == {"a": 1, "b": 1, "c": {"a": "a", "b": "b", "c": 2}}
+
+        assert search(
+            client=source_client,
+            index=REINDEXER_REVISION_2,
+        ) == {"a": 1, "b": 1, "c": json.dumps({"a": "a", "b": "b", "c": 2})}
+
+        assert search(
+            client=source_client,
+            index=REINDEXER_REVISION_3,
+        ) == {"a": 1, "c": json.dumps({"a": "a", "b": "b", "c": 2})}
+
+    def test_should_use_different_version_control_index_name(self, clean_up, load_data):
+        import opensearch_reindexer as osr
+
+        source_client = get_os_client()
+
+        osr.init()
+        modify_version_control_index()
+
+        # verify that "reindexer_version" index is initialized to version 0 when no revisions exist
         osr.init_index()
         assert search(
             client=source_client,
-            index=REINDEXER_VERSION,
-        ) == {"versionNum": 3}
+            index=MODIFIED_VERSION_CONTROL_INDEX_NAME,
+        ) == {"versionNum": 0}
 
+        # create revisions
+        osr.revision("revision_1", str(Language.python.value))
+        osr.revision("revision_2", str(Language.python.value))
+        osr.revision("revision_3", str(Language.python.value))
+
+        # modify revision files source/destination indices, mappings and transform_document
         modify_revision_files_python()
 
         osr.run()
 
-        assert source_client.indices.exists(REINDEXER_REVISION_3)
+        # The # docs in revision indices should match "reindexer_source_index"
+        expected_count = source_client.count(index=REINDEXER_SOURCE_INDEX)["count"]
+        assert (
+            source_client.count(index=REINDEXER_REVISION_1)["count"] == expected_count
+        )
+        assert (
+            source_client.count(index=REINDEXER_REVISION_2)["count"] == expected_count
+        )
+        assert (
+            source_client.count(index=REINDEXER_REVISION_3)["count"] == expected_count
+        )
 
-        assert source_client.indices.get_mapping(index=REINDEXER_REVISION_3) == {
-            "reindexer_revision_3": {
-                "mappings": {
-                    "properties": {
-                        "a": {"type": "long"},
-                        "c": {"type": "text"},
-                    }
-                }
-            }
-        }
+        # verify that documents were transformed as expected for each revision
+        assert search(
+            client=source_client,
+            index=REINDEXER_REVISION_1,
+        ) == {"a": 1, "b": 1, "c": {"a": "a", "b": "b", "c": 2}}
 
-    def test_should_create_destination_index_and_set_to_latest_revision_version_painless(self, clean_up):
-        # if revision files exist, reindexer_version index does not exist and the latest revision destination index does
-        # not exist, this tells us a project is being initialized for the first time and we want to create the
-        # destination index
+        assert search(
+            client=source_client,
+            index=REINDEXER_REVISION_2,
+        ) == {"a": 1, "b": 1, "c": json.dumps({"a": "a", "b": "b", "c": 2})}
+
+        assert search(
+            client=source_client,
+            index=REINDEXER_REVISION_3,
+        ) == {"a": 1, "c": json.dumps({"a": "a", "b": "b", "c": 2})}
+
+        assert search(
+            client=source_client,
+            index=MODIFIED_VERSION_CONTROL_INDEX_NAME,
+        ) == {"versionNum": 3}
+
+
+    def test_should_exit_when_source_index_does_not_exist_python(self, clean_up):
         import opensearch_reindexer as osr
 
         source_client = get_os_client()
@@ -101,34 +280,177 @@ class TestOpensearchReindexer:
         ) == {"versionNum": 0}
 
         # create revisions
-        osr.revision("revision_1", str(Language.painless.value))
-        osr.revision("revision_2", str(Language.painless.value))
-        osr.revision("revision_3", str(Language.painless.value))
+        osr.revision("revision_1", str(Language.python.value))
 
-        delete_index(source_client, REINDEXER_VERSION)
+        non_existent_index = "non_existent_index"
+        modify_revision_file(
+            file_name="1_revision_1",
+            modifications=[
+                ['SOURCE_INDEX = ""', f"SOURCE_INDEX = '{non_existent_index}'"],
+                [
+                    'DESTINATION_INDEX = ""',
+                    f"DESTINATION_INDEX = '{REINDEXER_REVISION_1}'",
+                ],
+            ],
+        )
 
+        with pytest.raises(SystemExit) as excinfo:
+            osr.run()
+
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+        assert source_client.indices.exists(index=non_existent_index) is False
+        assert source_client.indices.exists(index=REINDEXER_REVISION_1) is False
+
+    def test_should_exit_when_source_index_does_not_exist_painless(self, clean_up):
+        import opensearch_reindexer as osr
+
+        source_client = get_os_client()
+
+        osr.init()
+
+        # verify that "reindexer_version" index is initialized to version 0 when no revisions exist
         osr.init_index()
         assert search(
             client=source_client,
             index=REINDEXER_VERSION,
-        ) == {"versionNum": 3}
+        ) == {"versionNum": 0}
 
-        modify_revision_files_painless()
+        # create revisions
+        osr.revision("revision_1")
+
+        non_existent_index = "non_existent_index"
+        modify_revision_file(
+            file_name="1_revision_1",
+            modifications=[
+                [
+                    '"source": {"index": "source"},',
+                    f'"source": {{"index": "{non_existent_index}"}},',
+                ],
+                [
+                    '"dest": {"index": "destination"},',
+                    f'"dest": {{"index": "{REINDEXER_REVISION_1}"}},',
+                ],
+            ],
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            osr.run()
+
+        # assert that the correct exit code was used
+        assert excinfo.value.code == 1
+        assert source_client.indices.exists(index=non_existent_index) is False
+        assert source_client.indices.exists(index=REINDEXER_REVISION_1) is False
+
+    def test_should_create_destination_index_and_not_reindex_when_source_index_is_none_python(
+        self, clean_up
+    ):
+        import opensearch_reindexer as osr
+
+        source_client = get_os_client()
+
+        osr.init()
+
+        # verify that "reindexer_version" index is initialized to version 0 when no revisions exist
+        osr.init_index()
+        assert search(
+            client=source_client,
+            index=REINDEXER_VERSION,
+        ) == {"versionNum": 0}
+
+        # create revisions
+        osr.revision("revision_1", str(Language.python.value))
+
+        modify_revision_file(
+            file_name="1_revision_1",
+            modifications=[
+                ['SOURCE_INDEX = ""', f"SOURCE_INDEX = None"],
+                [
+                    'DESTINATION_INDEX = ""',
+                    f"DESTINATION_INDEX = '{REINDEXER_REVISION_1}'",
+                ],
+                [
+                    "DESTINATION_INDEX_BODY = None",
+                    f"DESTINATION_INDEX_BODY = {REVISION_ONE_MAPPINGS}",
+                ],
+            ],
+        )
 
         osr.run()
 
-        assert source_client.indices.exists(REINDEXER_REVISION_3)
+        # Expect destination index to be created
+        assert source_client.indices.exists(REINDEXER_REVISION_1) is True
 
-        assert source_client.indices.get_mapping(index=REINDEXER_REVISION_3) == {
-            "reindexer_revision_3": {
-                "mappings": {
-                    "properties": {
-                        "a": {"type": "long"},
-                        "c": {"type": "text"},
-                    }
-                }
-            }
-        }
+        # No reindexing should have occurred because source index is None
+        assert source_client.count(index=REINDEXER_REVISION_1)["count"] == 0
+        assert (
+            source_client.indices.get_mapping(index=REINDEXER_REVISION_1)[
+                REINDEXER_REVISION_1
+            ]
+            == REVISION_ONE_MAPPINGS
+        )
+
+        # versionNum should be incremented if source index is None and destination index does not exist.
+        assert search(
+            client=source_client,
+            index=REINDEXER_VERSION,
+        ) == {"versionNum": 1}
+
+    def test_should_create_destination_index_and_not_reindex_when_source_index_is_none_painless(
+        self, clean_up
+    ):
+        import opensearch_reindexer as osr
+
+        source_client = get_os_client()
+
+        osr.init()
+
+        # verify that "reindexer_version" index is initialized to version 0 when no revisions exist
+        osr.init_index()
+        assert search(
+            client=source_client,
+            index=REINDEXER_VERSION,
+        ) == {"versionNum": 0}
+
+        # create revisions
+        osr.revision("revision_1")
+
+        modify_revision_file(
+            file_name="1_revision_1",
+            modifications=[
+                [
+                    '"source": {"index": "source"},',
+                    f'"source": {{"index": None}},',
+                ],
+                [
+                    '"dest": {"index": "destination"},',
+                    f'"dest": {{"index": "{REINDEXER_REVISION_1}"}},',
+                ],
+                [
+                    "DESTINATION_INDEX_BODY = None",
+                    f"DESTINATION_INDEX_BODY = {REVISION_ONE_MAPPINGS}",
+                ],
+            ],
+        )
+        osr.run()
+
+        # Expect destination index to be created
+        assert source_client.indices.exists(REINDEXER_REVISION_1) is True
+
+        # No reindexing should have occurred because source index is None
+        assert source_client.count(index=REINDEXER_REVISION_1)["count"] == 0
+        assert (
+            source_client.indices.get_mapping(index=REINDEXER_REVISION_1)[
+                REINDEXER_REVISION_1
+            ]
+            == REVISION_ONE_MAPPINGS
+        )
+
+        # versionNum should be incremented if source index is None and destination index does not exist.
+        assert search(
+            client=source_client,
+            index=REINDEXER_VERSION,
+        ) == {"versionNum": 1}
 
     def test_setup_and_run_revisions_python(self, clean_up, load_data):
         import opensearch_reindexer as osr
@@ -182,15 +504,6 @@ class TestOpensearchReindexer:
             index=REINDEXER_REVISION_3,
         ) == {"a": 1, "c": json.dumps({"a": "a", "b": "b", "c": 2})}
 
-        # should find latest revision and initialize "reindexer_version to it if cluster has not been initialized.
-        # This occurs when someone has re-indexed from one cluster to another
-        source_client.indices.delete(index=REINDEXER_VERSION)
-        osr.init_index()
-        assert search(
-            client=source_client,
-            index=REINDEXER_VERSION,
-        ) == {"versionNum": 3}
-
     def test_setup_and_run_revisions_painless(self, clean_up, load_data):
         import opensearch_reindexer as osr
 
@@ -243,37 +556,8 @@ class TestOpensearchReindexer:
             index=REINDEXER_REVISION_3,
         ) == {"a": 1, "c": '{"a":"a","b":"b","c":"2"}'}
 
-        # should find latest revision and initialize "reindexer_version to it if cluster has not been initialized.
-        # This occurs when someone has re-indexed from one cluster to another
-        source_client.indices.delete(index=REINDEXER_VERSION)
-        osr.init_index()
-        assert search(
-            client=source_client,
-            index=REINDEXER_VERSION,
-        ) == {"versionNum": 3}
-
 
 def modify_revision_files_python():
-    revision_one_mappings = {
-        "mappings": {
-            "properties": {
-                "a": {"type": "long"},
-                "b": {"type": "long"},
-                "c": {
-                    "properties": {
-                        "a": {
-                            "type": "text",
-                        },
-                        "b": {
-                            "type": "text",
-                        },
-                        "c": {"type": "long"},
-                    }
-                },
-            }
-        }
-    }
-
     modify_revision_file(
         file_name="1_revision_1",
         modifications=[
@@ -284,7 +568,7 @@ def modify_revision_files_python():
             ],
             [
                 "DESTINATION_INDEX_BODY = None",
-                f"DESTINATION_INDEX_BODY = {revision_one_mappings}",
+                f"DESTINATION_INDEX_BODY = {REVISION_ONE_MAPPINGS}",
             ],
         ],
     )
@@ -305,14 +589,6 @@ def modify_revision_files_python():
             ["return doc", revision_two_code],
         ],
     )
-    revision_three_mappings = {
-        "mappings": {
-            "properties": {
-                "a": {"type": "long"},
-                "c": {"type": "text"},
-            }
-        }
-    }
     revision_three_code = """
             del doc['b']
             return doc
@@ -327,7 +603,7 @@ def modify_revision_files_python():
             ],
             [
                 "DESTINATION_INDEX_BODY = None",
-                f"DESTINATION_INDEX_BODY = {revision_three_mappings}",
+                f"DESTINATION_INDEX_BODY = {REVISION_THREE_MAPPINGS}",
             ],
             ["return doc", revision_three_code],
         ],
@@ -335,25 +611,6 @@ def modify_revision_files_python():
 
 
 def modify_revision_files_painless():
-    revision_one_mappings = {
-        "mappings": {
-            "properties": {
-                "a": {"type": "long"},
-                "b": {"type": "long"},
-                "c": {
-                    "properties": {
-                        "a": {
-                            "type": "text",
-                        },
-                        "b": {
-                            "type": "text",
-                        },
-                        "c": {"type": "long"},
-                    }
-                },
-            }
-        }
-    }
     reindex_body_source = '"source": {"index": "source"},'
     reindex_body_destination = '"dest": {"index": "destination"},'
 
@@ -370,7 +627,7 @@ def modify_revision_files_painless():
             ],
             [
                 "DESTINATION_INDEX_BODY = None",
-                f"DESTINATION_INDEX_BODY = {revision_one_mappings}",
+                f"DESTINATION_INDEX_BODY = {REVISION_ONE_MAPPINGS}",
             ],
         ],
     )
@@ -403,14 +660,6 @@ ctx._source.c = jsonString;
         ],
     )
 
-    revision_three_mappings = {
-        "mappings": {
-            "properties": {
-                "a": {"type": "long"},
-                "c": {"type": "text"},
-            }
-        }
-    }
     painless_script = str(
         {"script": {"lang": "painless", "source": "ctx._source.remove('b')"}}
     )
@@ -424,7 +673,7 @@ ctx._source.c = jsonString;
             ],
             [
                 "DESTINATION_INDEX_BODY = None",
-                f"DESTINATION_INDEX_BODY = {revision_three_mappings}",
+                f"DESTINATION_INDEX_BODY = {REVISION_THREE_MAPPINGS}",
             ],
         ],
     )
@@ -479,7 +728,39 @@ def modify_revision_file(file_name: str, modifications: list[list[str]]):
         f.write(contents)
 
 
+def modify_destination_client_env_file():
+    # Open the file in read-only mode and read its contents into a string
+    with open(f"./migrations/env.py", "r") as f:
+        contents = f.read()
+        destination_client = """destination_client = OpenSearch(
+    hosts=[{"host": "127.0.0.1", "port": OPENSEARCH_PORT}],
+    http_compress=True,  # enables gzip compression for request bodies
+    http_auth=(OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD),
+    use_ssl=OPENSEARCH_USE_SSL,
+    verify_certs=OPENSEARCH_VERIFY_CERTS,
+    ssl_show_warn=False,
+)
+        """
+        contents = contents.replace("destination_client = source_client", destination_client)
+
+    # Open the file in write mode and write the modified contents back to the file
+    with open(f"./migrations/env.py", "w") as f:
+        f.write(contents)
+
+
+def modify_version_control_index():
+    # Open the file in read-only mode and read its contents into a string
+    with open(f"./migrations/env.py", "r") as f:
+        contents = f.read()
+        version_control_index = f'VERSION_CONTROL_INDEX = "{MODIFIED_VERSION_CONTROL_INDEX_NAME}"'
+        contents = contents.replace('VERSION_CONTROL_INDEX = "reindexer_version"', version_control_index)
+
+    # Open the file in write mode and write the modified contents back to the file
+    with open(f"./migrations/env.py", "w") as f:
+        f.write(contents)
+
+
 def search(client: OpenSearch, index: str) -> dict:
-    return client.search(index=index, size=1, body={},)["hits"]["hits"][
+    return client.search(index=index, size=1, body={})["hits"]["hits"][
         0
     ]["_source"]

--- a/tests/e2e/test_opensearch_reindexer.py
+++ b/tests/e2e/test_opensearch_reindexer.py
@@ -60,7 +60,9 @@ def clean_up():
     delete_index(source_client, ALIAS_INDEX)
     delete_index(source_client, ALIAS_MODIFIED_INDEX)
     source_client.indices.delete_alias(name=ALIAS, index=ALIAS_INDEX, ignore=[404])
-    source_client.indices.delete_alias(name=ALIAS, index=ALIAS_MODIFIED_INDEX, ignore=[404])
+    source_client.indices.delete_alias(
+        name=ALIAS, index=ALIAS_MODIFIED_INDEX, ignore=[404]
+    )
 
     if os.path.exists("./migrations"):
         shutil.rmtree("./migrations")
@@ -104,8 +106,22 @@ class TestOpensearchReindexerHelper:
         assert result is None
 
     def test_should_increment_index(self, clean_up):
-        inputs = ["my-index", "my-index-0", "my-index-longer", "my-index-9", "my-index-", "-my-index"]
-        outputs = ["my-index-0", "my-index-1", "my-index-longer-0", "my-index-10", "my-index--0", "-my-index-0"]
+        inputs = [
+            "my-index",
+            "my-index-0",
+            "my-index-longer",
+            "my-index-9",
+            "my-index-",
+            "-my-index",
+        ]
+        outputs = [
+            "my-index-0",
+            "my-index-1",
+            "my-index-longer-0",
+            "my-index-10",
+            "my-index--0",
+            "-my-index-0",
+        ]
 
         for i, val in enumerate(inputs):
             assert helper.increment_index(val) == outputs[i]


### PR DESCRIPTION
**Support for the following was added.**
1. Multiple indices
2. Migration steps from another schema management tool to OpenSearch reindexer
3. Cross-cluster migration
4. Overriding version_control_index in ./migrations/env.py
5. Ability to create indices without performing reindexing by setting source index to None
6. Add `before_revision` and `after_revision` hooks.